### PR TITLE
Profile edit fix

### DIFF
--- a/molo/profiles/forms.py
+++ b/molo/profiles/forms.py
@@ -71,6 +71,14 @@ class EditProfileForm(forms.ModelForm):
         model = UserProfile
         fields = ['alias', 'date_of_birth']
 
+    def clean(self):
+        alias = self.cleaned_data.get('alias', None)
+        date_of_birth = self.cleaned_data.get('date_of_birth', None)
+        if (alias or date_of_birth):
+            return self.cleaned_data
+        else:
+            raise forms.ValidationError(_('Please enter a new value.'))
+
 
 class ProfilePasswordChangeForm(forms.Form):
     old_password = forms.RegexField(

--- a/molo/profiles/forms.py
+++ b/molo/profiles/forms.py
@@ -63,7 +63,8 @@ class EditProfileForm(forms.ModelForm):
     date_of_birth = forms.DateField(
         widget=SelectDateWidget(
             years=list(reversed([y for y in range(1930, datetime.now().year)]))
-        )
+        ),
+        required=False
     )
 
     class Meta:

--- a/molo/profiles/tests/test_views.py
+++ b/molo/profiles/tests/test_views.py
@@ -141,8 +141,8 @@ class MyProfileEditTest(TestCase):
     def test_update_no_input(self):
         response = self.client.post(reverse('molo.profiles:edit_my_profile'),
                                     {})
-        self.assertRedirects(
-            response, reverse('molo.profiles:edit_my_profile'))
+        self.assertFormError(
+            response, 'form', None, ['Please enter a new value.'])
 
     def test_update_alias_and_dob(self):
         response = self.client.post(reverse('molo.profiles:edit_my_profile'),

--- a/molo/profiles/tests/test_views.py
+++ b/molo/profiles/tests/test_views.py
@@ -126,7 +126,25 @@ class MyProfileEditTest(TestCase):
         form = response.context['form']
         self.assertTrue(isinstance(form, EditProfileForm))
 
-    def test_update(self):
+    def test_update_alias_only(self):
+        response = self.client.post(reverse('molo.profiles:edit_my_profile'),
+                                    {
+            'alias': 'foo'
+        })
+        self.assertRedirects(
+            response, reverse('molo.profiles:view_my_profile'))
+        self.assertEqual(UserProfile.objects.get(user=self.user).alias,
+                         'foo')
+
+    # Test for update with dob only is in ProfileDateOfBirthEditTest
+
+    def test_update_no_input(self):
+        response = self.client.post(reverse('molo.profiles:edit_my_profile'),
+                                    {})
+        self.assertRedirects(
+            response, reverse('molo.profiles:edit_my_profile'))
+
+    def test_update_alias_and_dob(self):
         response = self.client.post(reverse('molo.profiles:edit_my_profile'),
                                     {
             'alias': 'foo',
@@ -136,6 +154,8 @@ class MyProfileEditTest(TestCase):
             response, reverse('molo.profiles:view_my_profile'))
         self.assertEqual(UserProfile.objects.get(user=self.user).alias,
                          'foo')
+        self.assertEqual(UserProfile.objects.get(user=self.user).date_of_birth,
+                         date(2000, 1, 1))
 
 
 @override_settings(


### PR DESCRIPTION
Users should be able to change their alias without being required to enter something for the date of birth field as well. 
