### PR TITLE
Update compatibility for wagtail>=1.5

### DIFF
--- a/molo/profiles/admin.py
+++ b/molo/profiles/admin.py
@@ -8,7 +8,7 @@ from django.contrib.admin.sites import NotRegistered
 from django.utils.translation import ugettext_lazy as _
 
 from daterange_filter.filter import DateRangeFilter
-from wagtailmodeladmin.options import ModelAdmin as WagtailModelAdmin
+from wagtail.contrib.modeladmin.options import ModelAdmin as WagtailModelAdmin
 from molo.profiles.admin_views import FrontendUsersAdminView
 
 try:

--- a/molo/profiles/admin_views.py
+++ b/molo/profiles/admin_views.py
@@ -1,4 +1,4 @@
-from wagtailmodeladmin.views import IndexView
+from wagtail.contrib.modeladmin.views import IndexView
 from wagtail.wagtailadmin import messages
 from django.utils.translation import ugettext as _
 from task import send_export_email

--- a/molo/profiles/templates/admin/frontend_users_admin_view.html
+++ b/molo/profiles/templates/admin/frontend_users_admin_view.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailmodeladmin_tags admin_static admin_modify %}
+{% load i18n modeladmin_tags admin_static admin_modify %}
 {% load admin_urls %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}

--- a/molo/profiles/tests/test_admin.py
+++ b/molo/profiles/tests/test_admin.py
@@ -88,7 +88,7 @@ class TestFrontendUsersAdminView(TestCase):
 
     def test_staff_users_are_not_shown(self):
         response = self.client.get(
-            '/admin/modeladmin/auth/user/?usertype=frontend'
+            '/admin/auth/user/?usertype=frontend'
         )
         self.assertContains(response, self.user.username)
         self.assertNotContains(response, self.superuser.email)
@@ -100,7 +100,7 @@ class TestFrontendUsersAdminView(TestCase):
         profile.date_of_birth = date(1985, 1, 1)
         profile.mobile_number = '+27784667723'
         profile.save()
-        response = self.client.post('/admin/modeladmin/auth/user/')
+        response = self.client.post('/admin/auth/user/')
 
         self.assertEquals(response.status_code, 302)
 
@@ -124,7 +124,7 @@ class TestAdminUserView(TestCase):
 
     def test_exclude_all_end_users(self):
         response = self.client.get(
-            '/admin/modeladmin/auth/user/?usertype=admin'
+            '/admin/auth/user/?usertype=admin'
         )
         self.assertContains(response, self.superuser.username)
         self.assertNotContains(response, self.user.username)

--- a/molo/profiles/wagtail_hooks.py
+++ b/molo/profiles/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from molo.profiles.admin import FrontendUsersModelAdmin
-from wagtailmodeladmin.options import wagtailmodeladmin_register
+from wagtail.contrib.modeladmin.options import modeladmin_register
 
 
-wagtailmodeladmin_register(FrontendUsersModelAdmin)
+modeladmin_register(FrontendUsersModelAdmin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 molo.core<4.0.0,>=3.14.0
 celery<4.0
-wagtailmodeladmin
 django-phonenumber-field
 django-import-export
 django-daterange-filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-molo.core<4.0.0,>=3.14.0
+molo.core<5.0.0,>=4.0.0
 celery<4.0
 django-phonenumber-field
 django-import-export


### PR DESCRIPTION
Remove dependencies on wagtailmodeladmin module, which is incorporated into wagtaill>=1.5. Molo>=4 uses Wagtail>=1.8